### PR TITLE
Over budget warning

### DIFF
--- a/source/rolx-client/src/app/projects/shared/activity/table/activity-table.component.html
+++ b/source/rolx-client/src/app/projects/shared/activity/table/activity-table.component.html
@@ -37,7 +37,10 @@
   <ng-container matColumnDef="actualHours">
     <th mat-header-cell *matHeaderCellDef>Ist</th>
     <td mat-cell *matCellDef="let activity">
-      {{tpd(activity).actual.personDays | number:'1.1-1'}} PT
+      {{tpd(activity).actual.personDays | number:'1.1-1'}} PT 
+      <mat-icon color="warn" *ngIf="isOverBudget(activity)">
+        warning
+      </mat-icon>
     </td>
   </ng-container>
 

--- a/source/rolx-client/src/app/projects/shared/activity/table/activity-table.component.scss
+++ b/source/rolx-client/src/app/projects/shared/activity/table/activity-table.component.scss
@@ -27,3 +27,13 @@ tr {
     transition: opacity 0.3s ease-in;
   }
 }
+
+
+.mat-icon {
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+td {
+  vertical-align: middle;
+}

--- a/source/rolx-client/src/app/projects/shared/activity/table/activity-table.component.ts
+++ b/source/rolx-client/src/app/projects/shared/activity/table/activity-table.component.ts
@@ -65,4 +65,8 @@ export class ActivityTableComponent implements OnInit {
   tpd(activity: Activity): Activity {
     return activity;
   }
+
+  isOverBudget(activity: Activity): boolean {
+    return activity.actual.personDays > activity.budget.personDays;
+  }
 }

--- a/source/rolx-client/src/app/projects/shared/activity/table/activity-table.component.ts
+++ b/source/rolx-client/src/app/projects/shared/activity/table/activity-table.component.ts
@@ -67,6 +67,6 @@ export class ActivityTableComponent implements OnInit {
   }
 
   isOverBudget(activity: Activity): boolean {
-    return activity.actual.personDays > activity.budget.personDays;
+    return activity.actual.personDays > activity.budget.personDays && activity.budget.personDays > 0;
   }
 }


### PR DESCRIPTION
Added a warning icon to non-zero-budget-activities with actual (IST) values higher than the budget value.
Activities with empty/zero budget show no warning.